### PR TITLE
Copy in header components from current guild website

### DIFF
--- a/packages/shared-ui/.gitignore
+++ b/packages/shared-ui/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /components-types
+/dist

--- a/packages/shared-ui/.storybook/preview.js
+++ b/packages/shared-ui/.storybook/preview.js
@@ -1,4 +1,5 @@
+import './storybook.css'
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
+  actions: { argTypesRegex: '^on[A-Z].*' },
 }

--- a/packages/shared-ui/.storybook/storybook.css
+++ b/packages/shared-ui/.storybook/storybook.css
@@ -1,0 +1,3 @@
+:root {
+  --ifm-navbar-background-color: #fff;
+}

--- a/packages/shared-ui/components/Header.css
+++ b/packages/shared-ui/components/Header.css
@@ -1,0 +1,119 @@
+#g-header-bar {
+  background-color: var(--ifm-navbar-background-color);
+  color: var(--ifm-navbar-link-color);
+  width: 100%;
+  height: 55px;
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-bottom: 5px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.g-header-links {
+  margin-right: 10px;
+  color: var(--ifm-navbar-link-color);
+  font-family: 'Montserrat', sans-serif;
+  font-size: 12px;
+}
+/* The Modal (background) */
+.g-modal {
+  /* display: none; Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 10000; /* Sit on top */
+  padding-top: 100px; /* Location of the box */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  overflow: auto; /* Enable scroll if needed */
+  background-color: rgb(0, 0, 0); /* Fallback color */
+  background-color: rgba(0, 0, 0, 0.4); /* Black w/ opacity */
+}
+/* Modal Content */
+.g-modal-content {
+  background-color: var(--ifm-navbar-background-color);
+  margin: auto;
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%;
+}
+/* The Close Button */
+.g-close {
+  color: #aaaaaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+.g-close:hover,
+.g-close:focus {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+}
+.productTable h4 {
+  margin-bottom: 0px;
+  padding-bottom: 0px;
+}
+#oss-nav {
+  cursor: pointer;
+}
+.ossCells {
+  float: left;
+  padding: 11px;
+  margin-right: 5px;
+  background-color: white;
+}
+.ossContentCells {
+  float: left;
+  width: 325px;
+  padding-left: 5px;
+}
+:root {
+  --logo-bg: url('${linkUrl}/static/white-logo.png') no-repeat;
+  --logo-bg: url('${linkUrl}/static/logo.svg') no-repeat;
+}
+[data-theme='dark'] {
+  --logo-bg: url('${linkUrl}/static/white-logo.png') no-repeat;
+}
+.g-header-logo {
+  height: 45px;
+  background: var(--logo-bg);
+  width: 100px;
+}
+.g-modal-content {
+  width: 1000px;
+}
+.productTable {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  font-size: 15px;
+  text-align: left;
+  flex-wrap: wrap;
+}
+.flex-item-left {
+  box-sizing: border-box;
+  padding: 10px;
+  flex: 50%;
+}
+.flex-item-right {
+  box-sizing: border-box;
+  padding: 10px;
+  flex: 50%;
+}
+/* Responsive layout - makes a one column-layout instead of two-column layout */
+@media (max-width: 800px) {
+  .g-modal-content {
+    max-width: 95vw;
+    margin: auto;
+  }
+  .flex-container {
+    box-sizing: border-box;
+    flex-direction: column;
+  }
+  .ossContentCells {
+    width: 270px;
+  }
+}

--- a/packages/shared-ui/components/Header.stories.tsx
+++ b/packages/shared-ui/components/Header.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+import { Header, HeaderProps } from './Header'
+
+export default {
+  title: 'Header',
+  component: Header,
+  argTypes: {},
+} as Meta
+
+const Template: Story<HeaderProps> = args => <Header {...args}>Header</Header>
+
+export const Primary = Template.bind({})
+Primary.args = {
+  linkUrl: 'https://the-guild.dev',
+}

--- a/packages/shared-ui/components/Header.tsx
+++ b/packages/shared-ui/components/Header.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import './Header.css'
+import { HeaderModal } from './HeaderModal'
+
+export interface HeaderProps {
+  linkUrl: string
+}
+
+export const Header: React.FC<HeaderProps> = props => {
+  const { linkUrl = 'https://the-guild.dev' } = props
+
+  return (
+    <>
+      <div id="g-header-bar">
+        <a href={linkUrl} title="The Guild - Open Source">
+          <div className="g-header-logo"></div>
+          {/* <!--<picture>
+            <source srcset="${linkUrl}/static/white-logo.png" media="(prefers-color-scheme: dark)" />
+            <source srcset="${linkUrl}/static/logo.svg" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
+            <img src="${linkUrl}/static/logo.svg" alt="The Guild Logo"/ />
+          </picture>--> */}
+        </a>
+        <div>
+          <a href={`${linkUrl}/services`} className="g-header-links">
+            Our Services
+          </a>
+          <a id="oss-nav" className="g-header-links">
+            Open Source
+            <img
+              src={`${linkUrl}/static/go-down.svg`}
+              height="10"
+              width="12"
+              // style="color:black;"
+              style={{ color: 'black' }}
+            />
+          </a>
+          {/* <!--<a href="${linkUrl}/open-source" className="g-header-links">Products</a>--> */}
+          <a href={`${linkUrl}/blog`} className="g-header-links">
+            Blog
+          </a>
+          <a href={`${linkUrl}/about-us`} className="g-header-links">
+            Company
+          </a>
+        </div>
+      </div>
+      <HeaderModal />
+    </>
+  )
+}

--- a/packages/shared-ui/components/Header.tsx
+++ b/packages/shared-ui/components/Header.tsx
@@ -8,6 +8,7 @@ export interface HeaderProps {
 
 export const Header: React.FC<HeaderProps> = props => {
   const { linkUrl = 'https://the-guild.dev' } = props
+  const [modalOpen, setModalOpen] = React.useState(false)
 
   return (
     <>
@@ -24,13 +25,16 @@ export const Header: React.FC<HeaderProps> = props => {
           <a href={`${linkUrl}/services`} className="g-header-links">
             Our Services
           </a>
-          <a id="oss-nav" className="g-header-links">
+          <a
+            id="oss-nav"
+            className="g-header-links"
+            onClick={() => setModalOpen(true)}
+          >
             Open Source
             <img
               src={`${linkUrl}/static/go-down.svg`}
               height="10"
               width="12"
-              // style="color:black;"
               style={{ color: 'black' }}
             />
           </a>
@@ -43,7 +47,7 @@ export const Header: React.FC<HeaderProps> = props => {
           </a>
         </div>
       </div>
-      <HeaderModal />
+      {modalOpen && <HeaderModal onClose={() => setModalOpen(false)} />}
     </>
   )
 }

--- a/packages/shared-ui/components/HeaderModal.stories.tsx
+++ b/packages/shared-ui/components/HeaderModal.stories.tsx
@@ -6,7 +6,6 @@ import { HeaderModal, HeaderModalProps } from './HeaderModal'
 export default {
   title: 'HeaderModal',
   component: HeaderModal,
-  parameters: { actions: { argTypesRegex: '^on.*' } },
 } as Meta
 
 const Template: Story<HeaderModalProps> = args => (

--- a/packages/shared-ui/components/HeaderModal.stories.tsx
+++ b/packages/shared-ui/components/HeaderModal.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+import { HeaderModal, HeaderModalProps } from './HeaderModal'
+
+export default {
+  title: 'HeaderModal',
+  component: HeaderModal,
+  argTypes: {},
+} as Meta
+
+const Template: Story<HeaderModalProps> = args => (
+  <HeaderModal {...args}>HeaderModal</HeaderModal>
+)
+
+export const Primary = Template.bind({})
+Primary.args = {
+  linkUrl: 'https://the-guild.dev',
+}

--- a/packages/shared-ui/components/HeaderModal.stories.tsx
+++ b/packages/shared-ui/components/HeaderModal.stories.tsx
@@ -6,7 +6,7 @@ import { HeaderModal, HeaderModalProps } from './HeaderModal'
 export default {
   title: 'HeaderModal',
   component: HeaderModal,
-  argTypes: {},
+  parameters: { actions: { argTypesRegex: '^on.*' } },
 } as Meta
 
 const Template: Story<HeaderModalProps> = args => (

--- a/packages/shared-ui/components/HeaderModal.tsx
+++ b/packages/shared-ui/components/HeaderModal.tsx
@@ -18,7 +18,10 @@ export const HeaderModal: React.FC<HeaderModalProps> = props => {
         <h3>Featured Products</h3>
         <hr />
         {/* <!--<h3>GraphQL Products</h3>--> */}
-        <div className="productTable" align="center">
+        <div
+          className="productTable"
+          // align="center"
+        >
           <div className="flex-item-left">
             <div className="ossCells">
               <img

--- a/packages/shared-ui/components/HeaderModal.tsx
+++ b/packages/shared-ui/components/HeaderModal.tsx
@@ -1,0 +1,214 @@
+import React from 'react'
+import './Header.css'
+
+export interface HeaderModalProps {
+  linkUrl: string
+}
+
+export const HeaderModal: React.FC<HeaderModalProps> = props => {
+  const { linkUrl = 'https://the-guild.dev' } = props
+
+  return (
+    <div id="ossModal" className="g-modal">
+      <div className="g-modal-content">
+        <span className="g-close">&times;</span>
+        <h3>Featured Products</h3>
+        <hr />
+        {/* <!--<h3>GraphQL Products</h3>--> */}
+        <div className="productTable" align="center">
+          <div className="flex-item-left">
+            <div className="ossCells">
+              <img
+                src="https://graphql-code-generator.com/img/gql-codegen-cover.png"
+                width="100"
+              />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://graphql-code-generator.com/" target="_blank">
+                <h4>Code Generator</h4>
+              </a>
+              Generate code from GraphQL and operations
+            </div>
+          </div>
+          <div className="flex-item-right">
+            <div className="ossCells">
+              <img src={`${linkUrl}/img/logos/tools.svg`} width="100" />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://graphql-tools.com/" target="_blank">
+                <h4>GraphQL Tools</h4>
+              </a>
+              <p>
+                A set of utilities to build your JavaScript GraphQL schema in a
+                concise and powerful way.
+              </p>
+            </div>
+          </div>
+          <div className="flex-item-left">
+            <div className="ossCells">
+              <img src={`${linkUrl}/img/logos/modules.svg`} width="100" />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://graphql-modules.com/" target="_blank">
+                <h4>GraphQL Modules</h4>
+              </a>
+              GraphQL Modules lets you separate your backend implementation to
+              small, reusable, easy-to-implement and easy-to-test pieces.
+            </div>
+          </div>
+          <div className="flex-item-right">
+            <div className="ossCells">
+              <img src={`${linkUrl}/img/logos/scalars.svg`} width="100" />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://www.graphql-scalars.dev/" target="_blank">
+                <h4>GraphQL Scalars</h4>
+              </a>
+              A library of custom GraphQL Scalars for creating precise type-safe
+              GraphQL schemas.
+            </div>
+          </div>
+          <div className="flex-item-left">
+            <div className="ossCells">
+              <img
+                src="https://graphql-mesh.com/img/mesh-text-logo.svg"
+                width="100"
+              />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://graphql-mesh.com/" target="_blank">
+                <h4>GraphQL Mesh</h4>
+              </a>
+              GraphQL Mesh allows you to use GraphQL query language to access
+              data in remote APIs that don't run GraphQL (and also ones that do
+              run GraphQL).
+            </div>
+          </div>
+          <div className="flex-item-right">
+            <div className="ossCells">
+              <img
+                src={`${linkUrl}/img/logos/apollo-angular.svg`}
+                width="100"
+              />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://apollo-angular.com/" target="_blank">
+                <h4>Apollo Angular</h4>
+              </a>
+              A fully-featured, production ready caching GraphQL client for
+              Angular and every GraphQL server.
+            </div>
+          </div>
+          <div className="flex-item-left">
+            <div className="ossCells">
+              <img src={`${linkUrl}/img/logos/cli.svg`} width="100" />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://graphql-cli.com/" target="_blank">
+                <h4>GraphQL CLI</h4>
+              </a>
+              Command line tool for common GraphQL development workflows
+            </div>
+          </div>
+          <div className="flex-item-right">
+            <div className="ossCells">
+              <img src={`${linkUrl}/img/logos/config.svg`} width="100" />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://graphql-config.com/" target="_blank">
+                <h4>GraphQL Config</h4>
+              </a>
+              One configuration for all your GraphQL tools
+            </div>
+          </div>
+          <div className="flex-item-left">
+            <div className="ossCells">
+              <img src={`${linkUrl}/img/logos/sofa.svg`} width="100" />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://www.sofa-api.com/" target="_blank">
+                <h4>GraphQL SOFA</h4>
+              </a>
+              Generate RESTful APIs from your GraphQL Server
+            </div>
+          </div>
+          <div className="flex-item-right">
+            <div className="ossCells">
+              <img
+                src={`${linkUrl}/img/logos/stencil-apollo.svg`}
+                width="100"
+              />
+            </div>
+            <div className="ossContentCells">
+              <a
+                href="https://github.com/ardatan/stencil-apollo"
+                target="_blank"
+              >
+                <h4>Apollo Stencil</h4>
+              </a>
+              Stencil-Apollo lets you easily use GraphQL in Web Components.
+            </div>
+          </div>
+          <div className="flex-item-left">
+            <div className="ossCells">
+              <img
+                src="https://raw.githubusercontent.com/dotansimha/graphql-eslint/master/logo.png"
+                width="100"
+              />
+            </div>
+            <div className="ossContentCells">
+              <a
+                href="https://github.com/dotansimha/graphql-eslint/"
+                target="_blank"
+              >
+                <h4>GraphQL ESLint</h4>
+              </a>
+              GraphQL-ESLint integrates GraphQL AST in the ESLint core (as a
+              parser).
+            </div>
+          </div>
+          <div className="flex-item-right">
+            <div className="ossCells">
+              <img
+                src="https://graphql-inspector.com/img/logo.svg"
+                width="100"
+              />
+            </div>
+            <div className="ossContentCells">
+              <a href="https://graphql-inspector.com/" target="_blank">
+                <h4>GraphQL Inspector</h4>
+              </a>
+              GraphQL Inspector is a set of tools to help you better maintain
+              and improve GraphQL API as well as GraphQL consumers.
+            </div>
+          </div>
+          <div className="flex-item-left">
+            <div className="ossCells">
+              <img src={`${linkUrl}/img/logos/whats-app.svg`} width="100" />
+            </div>
+            <div className="ossContentCells">
+              <a
+                href="https://github.com/Urigo/WhatsApp-Clone-Tutorial"
+                target="_blank"
+              >
+                <h4>Whatsapp Clone Tutorial</h4>
+              </a>
+              An open-source full-stack example app.
+            </div>
+          </div>
+          {/* <!--<div className="flex-item-right">
+              <div className="ossCells">
+                <img src="https://graphql-inspector.com/img/logo.svg`} width="100" />
+              </div>
+              <div className="ossContentCells">
+                <a href="https://graphql-inspector.com/" target="_blank">
+                  <h4>GraphQL Inspector</h4>
+                </a>
+                GraphQL Inspector is a set of tools to help you better maintain and improve GraphQL API as well as GraphQL consumers.
+              </div>
+            </div>--> */}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/shared-ui/components/HeaderModal.tsx
+++ b/packages/shared-ui/components/HeaderModal.tsx
@@ -2,16 +2,19 @@ import React from 'react'
 import './Header.css'
 
 export interface HeaderModalProps {
-  linkUrl: string
+  linkUrl?: string
+  onClose: () => void
 }
 
 export const HeaderModal: React.FC<HeaderModalProps> = props => {
-  const { linkUrl = 'https://the-guild.dev' } = props
+  const { linkUrl = 'https://the-guild.dev', onClose } = props
 
   return (
     <div id="ossModal" className="g-modal">
       <div className="g-modal-content">
-        <span className="g-close">&times;</span>
+        <span className="g-close" onClick={onClose}>
+          &times;
+        </span>
         <h3>Featured Products</h3>
         <hr />
         {/* <!--<h3>GraphQL Products</h3>--> */}

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,18 +1,20 @@
 {
   "name": "guild-components",
   "version": "1.0.0",
-  "main": "components/index.tsx",
+  "license": "MIT",
+  "main": "dist/index.jsx",
   "types": "components-types/index.d.ts",
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "prepare" : "yarn run build",
+    "postversion" : "git push && git push --tags"
   },
   "dependencies": {
     "typescript": "^4.2.3"
   },
-  "license": "MIT",
   "devDependencies": {
     "@babel/core": "^7.13.10",
     "@storybook/addon-actions": "^6.1.21",

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "guild-components",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "dist/index.jsx",
   "types": "components-types/index.d.ts",
@@ -9,8 +9,9 @@
     "watch": "tsc --watch",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "prepare" : "yarn run build",
-    "postversion" : "git push && git push --tags"
+    "prepare": "yarn run build",
+    "version": "git add -A .",
+    "postversion": "git push && git push --tags"
   },
   "dependencies": {
     "typescript": "^4.2.3"

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,9 +1,13 @@
 {
   "name": "guild-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "dist/index.jsx",
   "types": "components-types/index.d.ts",
+  "files": [
+    "dist/**/*",
+    "components-types/**/*"
+  ],
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",

--- a/packages/shared-ui/tsconfig.json
+++ b/packages/shared-ui/tsconfig.json
@@ -14,9 +14,10 @@
     // Ensure that .d.ts files are created by tsc, but not .js files
     "declaration": true,
     "declarationDir": "components-types",
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
     // Ensure that Babel can safely transpile files in the TypeScript project
-    "isolatedModules": true
+    "isolatedModules": true,
+    "outDir": "./dist"
   },
   "include": ["components/**/*.tsx", "./../../types"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Header code has been copied from here:
https://github.com/the-guild-org/the-guild-website/blob/master/public/static/banner.js

It will be adjusted in the future to use twin.macro but the goal right now is to get a basic version working.

Items still to do:
* DONE: Show/hide modal
* DONE: Import package into guild website
* Optional: deploy Storybook

The components can be imported into another project by running `npm link` locally.

Note, you also need to npm link React within the project it’s used in like so: https://stackoverflow.com/a/65259365/2602771 (as otherwise you see a React Hooks duplicate React version error)